### PR TITLE
Grant access to Gamescope socket for Steam Deck

### DIFF
--- a/net.shadps4.shadPS4.yaml
+++ b/net.shadps4.shadPS4.yaml
@@ -23,6 +23,8 @@ finish-args:
   - --filesystem=home
   - --filesystem=/media
   - --filesystem=/run/media
+  # Required for Gamescope on Steam Deck
+  - --filesystem=xdg-run/gamescope-0:ro
 
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm19


### PR DESCRIPTION
See https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178

To replicate the error, install the Gamescope Flatpak,, launch a ROM in Game Mode, see error.