### PR TITLE
Drop ffmpeg extension

### DIFF
--- a/net.shadps4.shadPS4.yaml
+++ b/net.shadps4.shadPS4.yaml
@@ -33,14 +33,6 @@ finish-args:
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm21
 
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    add-ld-path: .
-    version: '25.08'
-    no-autodownload: false
-    autodelete: false
-
 cleanup-commands:
   - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 


### PR DESCRIPTION
Use the provided FFmpeg from the KDE runtime 6.10.

Solve https://github.com/flathub/net.shadps4.shadPS4/issues/41.